### PR TITLE
Allow an empty AWS session token

### DIFF
--- a/pipper/s3.py
+++ b/pipper/s3.py
@@ -21,7 +21,7 @@ def session_from_credentials_list(
 
     token = (
         credentials[2]
-        if len(credentials) > 2 and len(credentials[2]) > 1 else
+        if len(credentials) > 2 and credentials[2] is not None and len(credentials[2]) > 1 else
         None
     )
 


### PR DESCRIPTION
Allow AWS_SESSION_TOKEN to be empty when a session token is not required.

Steps to reproduce:

1. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
2. Leave AWS_SESSION_TOKEN unset
3. Try to install a package

Expected results:

The package installs

```
$ pipper install terraformer --bucket pipper-wiw

=== INSTALL ===

DOWNLOAD PATH: True /var/folders/dn/msp9f33d1bvcf9ttrtzngs5w0000gn/T/pipper-download-qzrmun3e/package.pipper
Processing /var/folders/dn/msp9f33d1bvcf9ttrtzngs5w0000gn/T/pipper-install-ip6lh3o9/terraformer-0.0.7-py2.py3-none-any.whl
Requirement already satisfied: ...
Installing collected packages: terraformer
Successfully installed terraformer-0.0.7
```


Actual results:

```
$ pipper install terraformer --bucket pipper-wiw
Traceback (most recent call last):
  File "/usr/local/bin/pipper", line 11, in <module>
    sys.exit(run())
  File "/usr/local/lib/python3.6/site-packages/pipper/command.py", line 46, in run
    env = Environment(args)
  File "/usr/local/lib/python3.6/site-packages/pipper/environment.py", line 29, in __init__
    default_repository
  File "/usr/local/lib/python3.6/site-packages/pipper/environment.py", line 171, in get_session
    return next(s for s in generate_session() if s is not None)
  File "/usr/local/lib/python3.6/site-packages/pipper/environment.py", line 171, in <genexpr>
    return next(s for s in generate_session() if s is not None)
  File "/usr/local/lib/python3.6/site-packages/pipper/environment.py", line 166, in generate_session
    yield s3.session_from_credentials_list(env_credentials)
  File "/usr/local/lib/python3.6/site-packages/pipper/s3.py", line 26, in session_from_credentials_list
    if len(credentials) > 2 and len(credentials[2]) > 1 else
TypeError: object of type 'NoneType' has no len()
```